### PR TITLE
Ask the bar to suppress the reveal, rather than assign it

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -269,7 +269,9 @@ Panel {
   }
 
   function setCenterHoverRevealSuppressed(value) {
-    if (root.bar && "centerHoverRevealSuppressed" in root.bar)
+    if (root.bar && typeof root.bar.setCenterHoverRevealSuppressed === "function")
+      root.bar.setCenterHoverRevealSuppressed(value)
+    else if (root.bar && "centerHoverRevealSuppressed" in root.bar)
       root.bar.centerHoverRevealSuppressed = value
   }
 


### PR DESCRIPTION
## The problem

On Omarchy 4.0.3 the panel opens and then will not close — by click or by hotkey. It stays on screen until the shell restarts. This is issue #1.

## Why

4.0.3 hands a third-party bar widget a `PluginBarApi` facade rather than the bar itself. On that facade `centerHoverRevealSuppressed` is `readonly`, backed by an internal `_centerHoverRevealSuppressed` the bar mirrors:

```qml
// shell/Ui/PluginBarApi.qml
property bool _centerHoverRevealSuppressed: false
readonly property bool centerHoverRevealSuppressed: _centerHoverRevealSuppressed

function setCenterHoverRevealSuppressed(value) {
  if (_setCenterHoverRevealSuppressed) _setCenterHoverRevealSuppressed(!!value)
}
```

So the assignment in `setCenterHoverRevealSuppressed()` now throws:

```
Panel.qml[273]: TypeError: Cannot assign to read-only property "centerHoverRevealSuppressed"
```

The damage is where it throws. `close()` calls it on its **first** line, so the exception takes `controller.hide()` down with it and the panel never hides:

```qml
function close() {
  setCenterHoverRevealSuppressed(false)   // throws here
  root.controller.hide()                  // never runs
}
```

`"centerHoverRevealSuppressed" in root.bar` is still `true` — the property exists, it just cannot be written — so the existing guard does not catch this.

## The fix

Prefer the setter the facade exposes, keeping the direct assignment as a fallback for an older shell. This is what the first-party panels already do — see `shell/plugins/panels/clock/Panel.qml` and `.../weather/Panel.qml`, which are byte-identical to this shape.

## Testing

- Reproduced on Omarchy 4.0.3 / nexthop 0.2.26: panel opens, will not close, log fills with the TypeError.
- With the patch, on the same setup: panel opens and closes normally, zero `centerHoverRevealSuppressed` errors in the shell log across several restarts.
- Also confirmed the bug is not version-specific — it reproduces identically on 0.2.9 and on 0.2.26.
- `omarchy plugin validate .` passes.

QML-only change; the Python daemon suite is untouched.

I left `manifest.json` alone, since versioning looks like a maintainer call given the `(0.2.x)` commit-title convention — happy to bump it if you'd prefer.
